### PR TITLE
reStructuredText でマークアップしたテキストの前後にスペースを入れるルールを追加

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,15 @@
 
 - 句点: `、`
 
+### スペース
+
+reStructuredText 記法でマークアップするテキストの前後には、半角スペースを挿入してください。
+reStructuredText 記法の詳細は [reStructuredText入門](http://docs.sphinx-users.jp/rest.html) を参照してください。
+
+```
+アクターは :class:`Actor` という基本 trait を拡張することで実装することができます。
+```
+
 最後に、可読性向上のため、原則として全角文字と半角文字の間に半角スペースをひとつ挿入してください。ただし、以下は例外とします。
 
 - 全角句読点と (reStructuredText 記法ではない) 半角英数字が続く場合


### PR DESCRIPTION
[この文章](https://akka-ja.netlify.com/scala/actors.html#アクターのクラスを定義する) のように、マークアップの前後にスペースが無いとうまく変換されない問題があったので、ルールを追加しました。
